### PR TITLE
fix: white CTA text on Supabase auth emails (#158)

### DIFF
--- a/docs/supabase-email-templates.md
+++ b/docs/supabase-email-templates.md
@@ -115,6 +115,7 @@ No modificar los nombres de estas variables salvo al añadir condicionales alred
 - Fondo: `#f5f3ef` (cream); tarjeta blanca, bordes redondeados.
 - Tipografía: Montserrat (en cliente de correo puede fallback a system fonts).
 - Pie: según idioma, texto equivalente en ES o EN + enlace a `{{ .SiteURL }}`.
+- **Botón CTA:** además de la clase `.button` en `<style>`, el `<a>` del botón debe incluir **`style="color: #ffffff !important"`** en línea. Clientes como Gmail suelen forzar el azul de enlace si el color solo está en la hoja de estilos embebida; el mismo patrón está en `src/lib/email/templates/demo-access.ts`.
 
 ## Error 500 "Error sending confirmation email" en producción
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -4,6 +4,8 @@
 
 ## Completado (resumen por áreas)
 
+- **Rama fix/email-auth-cta-white-text (issue #158):** En plantillas Supabase Auth (`magic_link`, `confirmation`, `recovery`, `invite`, `email_change`), el enlace del botón CTA lleva `style="color: #ffffff !important"` en línea para que el texto no salga en azul en Gmail y clientes similares. Doc actualizada en `docs/supabase-email-templates.md`.
+
 - **Rama feat/form-placeholder-foreground-typography:** Token `--placeholder-foreground` en `globals.css` (light/dark vía `color-mix`) para que los hints no usen el mismo color que el texto del campo; utilidad Tailwind `placeholder-foreground`; `Input`, `Textarea`, `SelectTrigger` con `text-foreground` y `placeholder:text-placeholder-foreground` / `data-[placeholder]:text-placeholder-foreground`; placeholder del `PhoneInput` alineado al token; formulario de contacto (textarea) actualizado. Lint, tests y build en Docker OK.
 
 - **Infra y auth:** Next.js 16 (App Router), Docker, Supabase (schema, RLS, Auth). Login/signup, magic links, sesión, caducidad con redirección. Migración desde Vite.

--- a/supabase/templates/confirmation.html
+++ b/supabase/templates/confirmation.html
@@ -97,7 +97,7 @@
         <h1>Welcome to Veta{{ if and .Data .Data.full_name }}, {{ .Data.full_name }}{{ end }}</h1>
         <p>Your account is one click away. Confirm your email address to activate it and start organising your interior design projects.</p>
         <p>
-          <a href="{{ .ConfirmationURL }}" class="button">Confirm and enter Veta</a>
+          <a href="{{ .ConfirmationURL }}" class="button" style="color: #ffffff !important">Confirm and enter Veta</a>
         </p>
         <p class="link-fallback">If the button does not work, copy and paste this link into your browser:<br /><a href="{{ .ConfirmationURL }}">{{ .ConfirmationURL }}</a></p>
         <hr class="divider" />
@@ -112,7 +112,7 @@
         <h1>Bienvenido/a a Veta{{ if and .Data .Data.full_name }}, {{ .Data.full_name }}{{ end }}</h1>
         <p>Tu cuenta está a un clic de distancia. Confirma tu dirección de correo para activarla y empieza a organizar tus proyectos de interiorismo.</p>
         <p>
-          <a href="{{ .ConfirmationURL }}" class="button">Confirmar y entrar a Veta</a>
+          <a href="{{ .ConfirmationURL }}" class="button" style="color: #ffffff !important">Confirmar y entrar a Veta</a>
         </p>
         <p class="link-fallback">Si el botón no funciona, copia y pega este enlace en tu navegador:<br /><a href="{{ .ConfirmationURL }}">{{ .ConfirmationURL }}</a></p>
         <hr class="divider" />

--- a/supabase/templates/email_change.html
+++ b/supabase/templates/email_change.html
@@ -86,7 +86,7 @@
         <h1>{{ if and .Data (eq .Data.lang "en") }}Confirm your new email{{ else }}Confirma tu nuevo correo{{ end }}</h1>
         <p>{{ if and .Data (eq .Data.lang "en") }}You asked to change your account email to {{ .NewEmail }}. To complete the change, click the button:{{ else }}Has solicitado cambiar el correo de tu cuenta a {{ .NewEmail }}. Para completar el cambio, haz clic en el botón:{{ end }}</p>
         <p>
-          <a href="{{ .ConfirmationURL }}" class="button">{{ if and .Data (eq .Data.lang "en") }}Confirm email{{ else }}Confirmar correo{{ end }}</a>
+          <a href="{{ .ConfirmationURL }}" class="button" style="color: #ffffff !important">{{ if and .Data (eq .Data.lang "en") }}Confirm email{{ else }}Confirmar correo{{ end }}</a>
         </p>
         <p class="link-fallback">{{ if and .Data (eq .Data.lang "en") }}If the button does not work, copy and paste this link:{{ else }}Si el botón no funciona, copia y pega este enlace:{{ end }}<br /><a href="{{ .ConfirmationURL }}">{{ .ConfirmationURL }}</a></p>
         <p style="font-size: 13px; color: #6b6560">{{ if and .Data (eq .Data.lang "en") }}If you did not request this change, you can ignore this email.{{ else }}Si no solicitaste este cambio, puedes ignorar este correo.{{ end }}</p>

--- a/supabase/templates/invite.html
+++ b/supabase/templates/invite.html
@@ -86,7 +86,7 @@
         <h1>{{ if and .Data (eq .Data.lang "en") }}You have been invited to Veta{{ else }}Te han invitado a Veta{{ end }}</h1>
         <p>{{ if and .Data (eq .Data.lang "en") }}You have been invited to join Veta, the platform for managing interior design projects. Click the button to accept the invitation and create your account:{{ else }}Esta es una invitación para unirte a Veta, la plataforma para gestionar proyectos de diseño interior. Haz clic en el botón para aceptar la invitación y crear tu cuenta:{{ end }}</p>
         <p>
-          <a href="{{ .ConfirmationURL }}" class="button">{{ if and .Data (eq .Data.lang "en") }}Accept invitation{{ else }}Aceptar invitación{{ end }}</a>
+          <a href="{{ .ConfirmationURL }}" class="button" style="color: #ffffff !important">{{ if and .Data (eq .Data.lang "en") }}Accept invitation{{ else }}Aceptar invitación{{ end }}</a>
         </p>
         <p class="link-fallback">{{ if and .Data (eq .Data.lang "en") }}If the button does not work, copy and paste this link:{{ else }}Si el botón no funciona, copia y pega este enlace:{{ end }}<br /><a href="{{ .ConfirmationURL }}">{{ .ConfirmationURL }}</a></p>
         <div class="footer">{{ if and .Data (eq .Data.lang "en") }}<a href="{{ .SiteURL }}">Veta</a> — Interior design project management.{{ else }}<a href="{{ .SiteURL }}">Veta</a> — Gestión de proyectos de diseño interior.{{ end }}</div>

--- a/supabase/templates/magic_link.html
+++ b/supabase/templates/magic_link.html
@@ -86,7 +86,7 @@
         <h1>{{ if and .Data (eq .Data.lang "en") }}Sign in to Veta{{ else }}Inicia sesión en Veta{{ end }}</h1>
         <p>{{ if and .Data (eq .Data.lang "en") }}Use the link below to access your account. The link is valid for a limited time:{{ else }}Usa el siguiente enlace para acceder a tu cuenta. El enlace es válido durante un tiempo limitado:{{ end }}</p>
         <p>
-          <a href="{{ .ConfirmationURL }}" class="button">{{ if and .Data (eq .Data.lang "en") }}Open Veta{{ else }}Acceder a Veta{{ end }}</a>
+          <a href="{{ .ConfirmationURL }}" class="button" style="color: #ffffff !important">{{ if and .Data (eq .Data.lang "en") }}Open Veta{{ else }}Acceder a Veta{{ end }}</a>
         </p>
         <p class="link-fallback">{{ if and .Data (eq .Data.lang "en") }}If the button does not work, copy and paste this link:{{ else }}Si el botón no funciona, copia y pega este enlace:{{ end }}<br /><a href="{{ .ConfirmationURL }}">{{ .ConfirmationURL }}</a></p>
         <div class="footer">{{ if and .Data (eq .Data.lang "en") }}<a href="{{ .SiteURL }}">Veta</a> — Interior design project management.{{ else }}<a href="{{ .SiteURL }}">Veta</a> — Gestión de proyectos de diseño interior.{{ end }}</div>

--- a/supabase/templates/recovery.html
+++ b/supabase/templates/recovery.html
@@ -86,7 +86,7 @@
         <h1>{{ if and .Data (eq .Data.lang "en") }}Reset your password{{ else }}Restablece tu contraseña{{ end }}</h1>
         <p>{{ if and .Data (eq .Data.lang "en") }}You requested a password reset for your Veta account ({{ .Email }}). Click the button to choose a new password:{{ else }}Has solicitado el restablecimiento de contraseña para tu cuenta en Veta con el correo {{ .Email }}. Haz clic en el botón para elegir una nueva contraseña:{{ end }}</p>
         <p>
-          <a href="{{ .ConfirmationURL }}" class="button">{{ if and .Data (eq .Data.lang "en") }}Reset password{{ else }}Restablecer contraseña{{ end }}</a>
+          <a href="{{ .ConfirmationURL }}" class="button" style="color: #ffffff !important">{{ if and .Data (eq .Data.lang "en") }}Reset password{{ else }}Restablecer contraseña{{ end }}</a>
         </p>
         <p class="link-fallback">{{ if and .Data (eq .Data.lang "en") }}If the button does not work, copy and paste this link:{{ else }}Si el botón no funciona, copia y pega este enlace:{{ end }}<br /><a href="{{ .ConfirmationURL }}">{{ .ConfirmationURL }}</a></p>
         <p style="font-size: 13px; color: #6b6560">{{ if and .Data (eq .Data.lang "en") }}If you did not request this, you can ignore this email. Your password will not be changed.{{ else }}Si no solicitaste este cambio, puedes ignorar este correo. Tu contraseña no se modificará.{{ end }}</p>


### PR DESCRIPTION
## Summary

Closes #158. Gmail and several other clients ignore link `color` when it is only set via an embedded `<style>` block on `.button`, so the magic link (and other Auth) CTAs showed **blue** label text on the green background.

## Changes

- Add inline `style="color: #ffffff !important"` on the primary CTA `<a>` in:
  - `supabase/templates/magic_link.html`
  - `supabase/templates/confirmation.html` (EN and ES variants)
  - `supabase/templates/recovery.html`, `invite.html`, `email_change.html`
- Document the requirement under **Diseño** in `docs/supabase-email-templates.md` (same approach as `demo-access.ts`).
- Update `memory-bank/progress.md`.

## Verification

- `npm run format`
- Docker (`docker compose run --rm app`): `npm run lint`, `npm run test -- run` (**326** tests passed), `npm run build` — all green.

## Deploy note

If hosted Supabase Auth templates were pasted manually in the dashboard, sync the updated HTML there after merge.