### PR TITLE
fix(security): CodeQL — magic link email validation and B2 URL host allowlist

### DIFF
--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -4,6 +4,8 @@
 
 ## Completado (resumen por áreas)
 
+- **Rama fix/security-codeql-magic-link-b2:** CodeQL / seguridad: `POST /api/auth/magic-link` valida el email con Zod (`trim`, máx. 254, `.email()`) en lugar de una regex polinómica (ReDoS). `src/lib/backblaze.ts`: comprobación de host B2 por sufijo `.backblazeb2.com` y solo `https:`; `src/lib/backblaze.url-guard.test.ts`.
+
 - **Rama fix/email-auth-cta-white-text (issue #158):** En plantillas Supabase Auth (`magic_link`, `confirmation`, `recovery`, `invite`, `email_change`), el enlace del botón CTA lleva `style="color: #ffffff !important"` en línea para que el texto no salga en azul en Gmail y clientes similares. Doc actualizada en `docs/supabase-email-templates.md`.
 
 - **Rama feat/form-placeholder-foreground-typography:** Token `--placeholder-foreground` en `globals.css` (light/dark vía `color-mix`) para que los hints no usen el mismo color que el texto del campo; utilidad Tailwind `placeholder-foreground`; `Input`, `Textarea`, `SelectTrigger` con `text-foreground` y `placeholder:text-placeholder-foreground` / `data-[placeholder]:text-placeholder-foreground`; placeholder del `PhoneInput` alineado al token; formulario de contacto (textarea) actualizado. Lint, tests y build en Docker OK.

--- a/src/app/api/auth/magic-link/route.ts
+++ b/src/app/api/auth/magic-link/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
 import {
   checkRateLimit,
@@ -18,6 +19,16 @@ import {
   MAGIC_LINK_CAPTCHA_BYPASS_COOKIE,
   verifyMagicLinkCaptchaBypassValue,
 } from "@/lib/auth/magic-link-captcha-bypass";
+
+/** RFC 5321 max length; caps input before Zod email check (ReDoS / abuse mitigation). */
+const MAGIC_LINK_EMAIL_MAX = 254;
+
+const magicLinkEmailSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(MAGIC_LINK_EMAIL_MAX)
+  .email();
 
 function shouldIssueCaptchaBypassCookie(
   email: string,
@@ -84,14 +95,15 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Email is required" }, { status: 400 });
     }
 
-    // Validate email format
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(email)) {
-      return NextResponse.json(
-        { error: "Invalid email format" },
-        { status: 400 }
-      );
+    const parsedEmail = magicLinkEmailSchema.safeParse(email);
+    if (!parsedEmail.success) {
+      const code = parsedEmail.error.issues[0]?.code;
+      const message =
+        code === "too_small" ? "Email is required" : "Invalid email format";
+      return NextResponse.json({ error: message }, { status: 400 });
     }
+
+    const normalizedEmail = parsedEmail.data;
 
     const antiSpamConfig = getMagicLinkAntiSpamConfig();
     const captchaTokenStr =
@@ -101,10 +113,10 @@ export async function POST(request: NextRequest) {
     )?.value;
     const captchaBypassVerified = verifyMagicLinkCaptchaBypassValue(
       bypassCookie,
-      email
+      normalizedEmail
     );
     const antiSpam = await resolveMagicLinkAntiSpam({
-      email,
+      email: normalizedEmail,
       captchaToken: captchaTokenStr,
       remoteIp: ip,
       captchaBypassVerified,
@@ -137,7 +149,7 @@ export async function POST(request: NextRequest) {
     const supabase = await createClient();
 
     const { error } = await supabase.auth.signInWithOtp({
-      email,
+      email: normalizedEmail,
       options: {
         emailRedirectTo,
         data: mergedWithAntiSpam,
@@ -161,7 +173,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: message }, { status });
     }
 
-    return jsonSuccessWithCaptchaBypassRefresh(email, antiSpamConfig);
+    return jsonSuccessWithCaptchaBypassRefresh(normalizedEmail, antiSpamConfig);
   } catch {
     return NextResponse.json(
       { error: "Internal server error" },

--- a/src/lib/backblaze.ts
+++ b/src/lib/backblaze.ts
@@ -301,6 +301,17 @@ export async function uploadDocument(params: {
   };
 }
 
+/** B2 download/file URLs use hostnames like f003.backblazeb2.com (never bare registrable-only checks). */
+const BACKBLAZE_B2_FILE_HOST_SUFFIX = ".backblazeb2.com";
+
+function isTrustedBackblazeB2FileHostname(hostname: string): boolean {
+  const h = hostname.toLowerCase();
+  return (
+    h.endsWith(BACKBLAZE_B2_FILE_HOST_SUFFIX) &&
+    h.length > BACKBLAZE_B2_FILE_HOST_SUFFIX.length
+  );
+}
+
 /**
  * Comprueba si una URL es de nuestro bucket B2.
  */
@@ -309,10 +320,11 @@ function isOurB2Url(imageUrl: string): boolean {
   if (!bucketName || !imageUrl?.trim()) return false;
   try {
     const url = new URL(imageUrl);
+    if (url.protocol !== "https:") return false;
+    if (!isTrustedBackblazeB2FileHostname(url.hostname)) return false;
     const pathParts = url.pathname.split("/").filter(Boolean);
     // Formato: /file/{bucketName}/{fileName}
     return (
-      url.hostname.includes("backblazeb2.com") &&
       pathParts[0] === "file" &&
       pathParts[1] === bucketName &&
       pathParts.length >= 3
@@ -331,6 +343,8 @@ function extractFileNameFromB2Url(imageUrl: string): string | null {
   if (!bucketName || !imageUrl?.trim()) return null;
   try {
     const url = new URL(imageUrl);
+    if (url.protocol !== "https:") return null;
+    if (!isTrustedBackblazeB2FileHostname(url.hostname)) return null;
     const pathParts = url.pathname.split("/").filter(Boolean);
     if (pathParts[0] !== "file" || pathParts[1] !== bucketName) return null;
     return decodeURIComponent(pathParts.slice(2).join("/"));

--- a/src/lib/backblaze.url-guard.test.ts
+++ b/src/lib/backblaze.url-guard.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { deleteProductImage } from "./backblaze";
+
+describe("deleteProductImage URL guard", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.stubEnv("B2_BUCKET_NAME", "my-bucket");
+    vi.stubEnv("B2_BUCKET_ID", "bucket-123");
+    vi.stubEnv("B2_APPLICATION_KEY_ID", "key-id");
+    vi.stubEnv("B2_APPLICATION_KEY", "key");
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("does not call fetch when host is not a real *.backblazeb2.com subdomain", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await deleteProductImage(
+      "https://evil.com/file/my-bucket/https%3A%2F%2Ff003.backblazeb2.com%2Ffile%2Fmy-bucket%2Fx.webp"
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not call fetch for look-alike host backblazeb2.com.evil.com", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await deleteProductImage(
+      "https://f003.backblazeb2.com.evil.com/file/my-bucket/x.webp"
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not call fetch when scheme is not https", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await deleteProductImage(
+      "http://f003.backblazeb2.com/file/my-bucket/x.webp"
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not call fetch when bucket in path does not match env", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await deleteProductImage(
+      "https://f003.backblazeb2.com/file/other-bucket/x.webp"
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Addresses CodeQL findings without mixing with other feature work.

1. **Magic link (`src/app/api/auth/magic-link/route.ts`):** Replaces the polynomial-time email regex with Zod (`trim`, max length 254 per RFC 5321, `.email()`). Uses `normalizedEmail` for anti-spam, captcha bypass verification, and `signInWithOtp`.

2. **Backblaze delete guard (`src/lib/backblaze.ts`):** Replaces `hostname.includes("backblazeb2.com")` with a proper host check: `https:` only and hostname ending with `.backblazeb2.com` with at least one label (suffix allowlist). Same checks in `extractFileNameFromB2Url`.

3. **Tests:** `src/lib/backblaze.url-guard.test.ts` ensures `deleteProductImage` does not call `fetch` for malicious or look-alike URLs.

## Verification

- **Docker:** `docker compose run --rm app` → `npm run lint`, `npx vitest run` (**330** tests), `npm run build` — all passed.

## Related

Security work was removed from `refactor/project-tabs-routing` (PR #160) so that PR stays focused on nested project tabs only.