### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/marcogonzalo/studio-manager/security/code-scanning/2](https://github.com/marcogonzalo/studio-manager/security/code-scanning/2)

Add an explicit workflow-level `permissions` block near the top of `.github/workflows/ci.yml` (after `on:` is typical) so all jobs inherit minimal token access by default. For this workflow, `contents: read` is the correct minimal baseline for checkout and read-only CI tasks. This resolves the CodeQL warning without changing workflow behavior.

Best single fix (minimal, non-functional change):
- File: `.github/workflows/ci.yml`
- Insert:
  - `permissions:`
  - `  contents: read`
- Place it before `jobs:` so both `test` and `security-audit` inherit it.

No imports/methods/dependencies are needed (YAML config change only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
