### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/marcogonzalo/studio-manager/security/code-scanning/1](https://github.com/marcogonzalo/studio-manager/security/code-scanning/1)

Add an explicit top-level `permissions` block to `.github/workflows/ci.yml` so all jobs inherit least-privilege token scopes by default.

Best fix here (without changing functionality): add at workflow root (after `on:` block and before `jobs:`):

- `permissions:`
  - `contents: read`

This is sufficient for checkout and typical read-only CI tasks, and avoids broad default write permissions. No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
