### PR TITLE
fix: redirect www homepage and remove www links

### DIFF
--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -4,7 +4,9 @@
 
 ## Completado (resumen por áreas)
 
-- **Rama feat/canonical-site-url:** Origen canónico unificado `https://veta.pro` (apex HTTPS, sin `www`) vía `src/lib/site-url.ts` (`getSiteUrl`, `isWwwVetaHost`). `metadataBase` en layout raíz y URLs absolutas en sitemap, robots, JSON-LD y landings marketing usan el helper. Redirect 308 de `www.veta.pro` en `proxy.ts` y redirect permanente en `vercel.json`. Tests unitarios en `site-url.test.ts`. Lint, tests (336) y build OK en host (Docker no disponible en la sesión).
+- **Rama fix/canonical-site-url-www:** Fix redirect `www.veta.pro` homepage (`/`): `vercel.json` rule `/:path*` no cubría la raíz → HTML en www + assets en apex → CSP bloqueaba CSS. Reglas explícitas `/` y `/:path+`. Links internos sin www en demo email y pie PDF. Tests demo-access.
+
+- **Rama feat/canonical-site-url (#166):** Origen canónico unificado `https://veta.pro` (apex HTTPS, sin `www`) vía `src/lib/site-url.ts` (`getSiteUrl`, `isWwwVetaHost`). `metadataBase` en layout raíz y URLs absolutas en sitemap, robots, JSON-LD y landings marketing usan el helper. Redirect 308 de `www.veta.pro` en `proxy.ts` y redirect permanente en `vercel.json`. Tests unitarios en `site-url.test.ts`. Lint, tests (336) y build OK en host (Docker no disponible en la sesión).
 
 - **Rama chore/pnpm-docker-ci:** El proyecto usa **pnpm** (`packageManager` en `package.json`, `pnpm-lock.yaml`, sin `package-lock.json`). Dockerfile (`corepack` + `pnpm install --frozen-lockfile`), CI (pnpm/action-setup + caché pnpm), `.dockerignore`, scripts de seed (`pnpm exec tsx`), README y `docs/ci-cd.md` alineados. Reglas Cursor y skills de agente actualizadas a comandos pnpm.
 

--- a/src/components/project-pdf.tsx
+++ b/src/components/project-pdf.tsx
@@ -842,7 +842,7 @@ export function ProjectPDF({
               />
             )}
             <Text style={styles.vetaFooterText}>
-              Document generated with Veta - www.veta.pro
+              Document generated with Veta - veta.pro
             </Text>
           </View>
         )}

--- a/src/lib/email/templates/demo-access.test.ts
+++ b/src/lib/email/templates/demo-access.test.ts
@@ -7,6 +7,8 @@ describe("demo-access email templates", () => {
   it("defaults to Spanish copy", () => {
     expect(getDemoAccessEmailHtml(link)).toContain("Prueba la demo");
     expect(getDemoAccessEmailText(link)).toContain("Hola");
+    expect(getDemoAccessEmailHtml(link)).toContain('href="https://veta.pro"');
+    expect(getDemoAccessEmailHtml(link)).not.toContain("www.veta.pro");
   });
 
   it("uses English when lang is en", () => {

--- a/src/lib/email/templates/demo-access.ts
+++ b/src/lib/email/templates/demo-access.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Locale } from "@/i18n/config";
+import { CANONICAL_SITE_ORIGIN } from "@/lib/site-url";
 
 function escapeHtml(link: string): string {
   return link
@@ -107,8 +108,8 @@ export function getDemoAccessEmailHtml(
     ? "If you did not request this link, you can ignore this email."
     : "Si no has solicitado este enlace, puedes ignorar este correo.";
   const footer = isEn
-    ? `<a href="https://www.veta.pro">Veta</a> — Interior design project management.`
-    : `<a href="https://www.veta.pro">Veta</a> — Gestión de proyectos de diseño interior.`;
+    ? `<a href="${CANONICAL_SITE_ORIGIN}">Veta</a> — Interior design project management.`
+    : `<a href="${CANONICAL_SITE_ORIGIN}">Veta</a> — Gestión de proyectos de diseño interior.`;
 
   return `<!doctype html>
 <html lang="${htmlLang}">

--- a/vercel.json
+++ b/vercel.json
@@ -3,9 +3,15 @@
   "framework": "nextjs",
   "redirects": [
     {
-      "source": "/:path*",
+      "source": "/",
       "has": [{ "type": "host", "value": "www.veta.pro" }],
-      "destination": "https://veta.pro/:path*",
+      "destination": "https://veta.pro/",
+      "permanent": true
+    },
+    {
+      "source": "/:path+",
+      "has": [{ "type": "host", "value": "www.veta.pro" }],
+      "destination": "https://veta.pro/:path+",
       "permanent": true
     }
   ]


### PR DESCRIPTION
## Summary

- Fix broken styling on `https://www.veta.pro/`: the previous `vercel.json` redirect used `/:path*`, which does not match the homepage `/`. HTML stayed on `www` while `/_next/static/*` redirected to apex; CSP `style-src 'self'` blocked cross-origin CSS/JS.
- Add explicit redirects for `/` and `/:path+` from `www.veta.pro` to `https://veta.pro`.
- Replace remaining `www.veta.pro` links in demo access email footer and PDF footer with apex `https://veta.pro`.

## Root cause

| URL | Before |
|-----|--------|
| `https://www.veta.pro/` | 200 (HTML on www) |
| `https://www.veta.pro/_next/static/*.css` | 308 → apex |

Page origin `www` + assets on `veta.pro` → CSP blocked stylesheets.

## Modified files

- `vercel.json`
- `src/lib/email/templates/demo-access.ts`
- `src/lib/email/templates/demo-access.test.ts`
- `src/components/project-pdf.tsx`
- `memory-bank/progress.md`

## Verification

- [x] Prettier
- [x] Lint
- [x] Tests: **336 passed**
- [x] Build
- [ ] Docker verification skipped (daemon unavailable)

## Test plan after deploy

- [ ] `curl -sI https://www.veta.pro/` → `308` with `location: https://veta.pro/`
- [ ] Browser visit `https://www.veta.pro/` → lands on styled `https://veta.pro/`
- [ ] Demo email HTML footer links to `https://veta.pro`